### PR TITLE
Withdrawals performance optimized

### DIFF
--- a/src/Lykke.Service.Bitcoin.Api.Core/Services/Transactions/ITransactionBuilderService.cs
+++ b/src/Lykke.Service.Bitcoin.Api.Core/Services/Transactions/ITransactionBuilderService.cs
@@ -1,17 +1,18 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Lykke.Service.Bitcoin.Api.Core.Domain.Operation;
-using NBitcoin;
 
 namespace Lykke.Service.Bitcoin.Api.Core.Services.Transactions
 {
     public interface ITransactionBuilderService
     {
         Task<IBuiltTransaction> GetManyOutputsTransferTransactionAsync(OperationInput fromAddress,
-            IList<OperationOutput> toAddresses);
+            IList<OperationOutput> toAddresses,
+            bool includeFee);
 
         Task<IBuiltTransaction> GetManyInputsTransferTransactionAsync(IList<OperationInput> fromAddresses,
-            OperationOutput toAddress);
+            OperationOutput toAddress,
+            bool includeFee);
 
         Task<IBuiltTransaction> GetTransferTransactionAsync(OperationInput fromAddress, OperationOutput toAddress,
             bool includeFee);

--- a/src/Lykke.Service.Bitcoin.Api.Services/Operations/OperationService.cs
+++ b/src/Lykke.Service.Bitcoin.Api.Services/Operations/OperationService.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Lykke.Service.Bitcoin.Api.Core.Domain.Operation;
 using Lykke.Service.Bitcoin.Api.Core.Domain.Transactions;
-using Lykke.Service.Bitcoin.Api.Core.Services;
 using Lykke.Service.Bitcoin.Api.Core.Services.Exceptions;
 using Lykke.Service.Bitcoin.Api.Core.Services.Operation;
 using Lykke.Service.Bitcoin.Api.Core.Services.TransactionOutputs;
@@ -56,11 +55,11 @@ namespace Lykke.Service.Bitcoin.Api.Services.Operations
 
                     break;
                 case OperationType.ManyInputs:
-                    builtTransaction = await _transactionBuilder.GetManyInputsTransferTransactionAsync(inputs, outputs.Single());
+                    builtTransaction = await _transactionBuilder.GetManyInputsTransferTransactionAsync(inputs, outputs.Single(), includeFee);
 
                     break;
                 case OperationType.ManyOutputs:
-                    builtTransaction = await _transactionBuilder.GetManyOutputsTransferTransactionAsync(inputs.Single(), outputs);
+                    builtTransaction = await _transactionBuilder.GetManyOutputsTransferTransactionAsync(inputs.Single(), outputs, includeFee);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(operationType));


### PR DESCRIPTION
In the case of a lot of withdrawals, each withdrawal waited for the previous to be confirmed. This PR removes this awaiting.