### PR TITLE
LM-2779 add Partial support of RPC to build transaction

### DIFF
--- a/src/Lykke.Job.Bitcoin/Modules/ServiceModule.cs
+++ b/src/Lykke.Job.Bitcoin/Modules/ServiceModule.cs
@@ -11,6 +11,7 @@ using Lykke.Service.Bitcoin.Api.Core.Services.BlockChainReaders;
 using Lykke.Service.Bitcoin.Api.Core.Services.Fee;
 using Lykke.Service.Bitcoin.Api.Services.Address;
 using Lykke.Service.Bitcoin.Api.Services.Asset;
+using Lykke.Service.Bitcoin.Api.Services.BlockChainProviders;
 using Lykke.Service.Bitcoin.Api.Services.BlockChainProviders.QbitNinja;
 using Lykke.Service.Bitcoin.Api.Services.Fee;
 using Lykke.Service.Bitcoin.Api.Services.ObservableOperation;
@@ -62,7 +63,14 @@ namespace Lykke.Job.Bitcoin.Modules
             var networkType = Network.GetNetwork(_settings.Network);
 
             builder.RegisterInstance(new QBitNinjaClient(_settings.NinjaApiUrl, networkType));
-            builder.RegisterType<NinjaApiBlockChainProvider>().As<IBlockChainProvider>();
+            if (_settings.UseRpcBlockchainProvider)
+            {
+                builder.RegisterType<RpcBlockchainProvider>().As<IBlockChainProvider>();
+            }
+            else
+            {
+                builder.RegisterType<NinjaApiBlockChainProvider>().As<IBlockChainProvider>();
+            }
             builder.RegisterInstance(new RPCClient(
                 new NetworkCredential(_settings.Rpc.UserName, _settings.Rpc.Password),
                 new Uri(_settings.Rpc.Host),

--- a/src/Lykke.Job.Bitcoin/Settings/ServiceSettings/BitcoinJobSettings.cs
+++ b/src/Lykke.Job.Bitcoin/Settings/ServiceSettings/BitcoinJobSettings.cs
@@ -1,4 +1,5 @@
-﻿using Lykke.Service.Bitcoin.Api.Core.Services.Fee;
+﻿using System.Data.SqlClient;
+using Lykke.Service.Bitcoin.Api.Core.Services.Fee;
 using Lykke.Service.Bitcoin.Api.Services.BlockChainProviders;
 using Lykke.SettingsReader.Attributes;
 
@@ -37,5 +38,8 @@ namespace Lykke.Job.Bitcoin.Settings.ServiceSettings
         public int StartFromBlockHeight { get; set; }
 
         public int IgnoreUnspentOutputsBeforeBlockHeight { get; set; }
+        
+        [Optional]
+        public bool UseRpcBlockchainProvider { get; set; }
     }
 }

--- a/src/Lykke.Service.Bitcoin.Api.Services/BlockChainProviders/RpcBlockchainProvider.cs
+++ b/src/Lykke.Service.Bitcoin.Api.Services/BlockChainProviders/RpcBlockchainProvider.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AsyncFriendlyStackTrace;
+using Common.Log;
+using Lykke.Common.Log;
+using Lykke.Service.Bitcoin.Api.Core.Services.Address;
+using Lykke.Service.Bitcoin.Api.Core.Services.BlockChainReaders;
+using Lykke.Service.Bitcoin.Api.Core.Services.Exceptions;
+using NBitcoin;
+using NBitcoin.RPC;
+
+namespace Lykke.Service.Bitcoin.Api.Services.BlockChainProviders
+{
+    public class RpcBlockchainProvider : IBlockChainProvider
+    {
+        private readonly RPCClient _client;
+        private readonly ILog _log;
+        private readonly IAddressValidator _addressValidator;
+
+        public RpcBlockchainProvider(RPCClient client, 
+            ILogFactory logFactory, IAddressValidator addressValidator)
+        {
+            _client = client;
+            _addressValidator = addressValidator;
+            _log = logFactory.CreateLog(nameof(RpcBlockchainProvider));
+        }
+
+        public async Task BroadCastTransactionAsync(Transaction tx)
+        {
+            _log.Info("Using RPC Provider to Broadcast");
+            try
+            {
+                await _client.SendRawTransactionAsync(tx);
+            }
+            catch (RPCException ex) when (ex.RPCCode == RPCErrorCode.RPC_VERIFY_REJECTED && ex.Message == "257: txn-already-known")
+            {
+                throw new BusinessException("Transaction already brodcasted", ErrorCode.TransactionAlreadyBroadcasted);
+            }
+        }
+
+        public async Task<int> GetTxConfirmationCountAsync(string txHash)
+        {
+            _log.Info("Using RPC Provider to GetTxConfirmationCountAsync");
+            try
+            {
+                var tx = await _client.GetRawTransactionInfoAsync(uint256.Parse(txHash));
+
+                return (int)tx.Confirmations;
+            }
+            catch (RPCException e) when(e.RPCCode == RPCErrorCode.RPC_INVALID_ADDRESS_OR_KEY)
+            {
+                _log.Info(nameof(RpcBlockchainProvider), nameof(GetTxConfirmationCountAsync), $"Tx not found {e.ToAsyncString()}");
+
+                return 0;
+            }
+        }
+
+        public async Task<IList<Coin>> GetUnspentOutputsAsync(string address, int minConfirmationCount)
+        {
+            _log.Info("Using RPC Provider to GetUnspentOutputsAsync");
+            var btcAddr = _addressValidator.GetBitcoinAddress(address);
+
+            if (btcAddr == null)
+            {
+                throw new ArgumentException("Unable to recognize address", nameof(address));
+            }
+
+            var rpcResponse = await _client.ListUnspentAsync(minConfirmationCount, int.MaxValue, btcAddr);
+
+            return rpcResponse.Select(p => new Coin(p.OutPoint, new TxOut(p.Amount, p.ScriptPubKey))).ToList();
+        }
+
+        public Task<IList<ColoredCoin>> GetColoredUnspentOutputsAsync(string address, int minConfirmationCount)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<int> GetLastBlockHeightAsync()
+        {
+            _log.Info("Using RPC Provider to GetLastBlockHeightAsync");
+            return _client.GetBlockCountAsync();
+        }
+
+        public Task<IEnumerable<BitcoinTransaction>> GetTransactionsAfterTxAsync(string address, string afterHash)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<IEnumerable<string>> GetInvolvedInTxAddresses(string txHash)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<IEnumerable<(string txHash, IEnumerable<string> destinationAddresses)>> GetTxOutputAddresses(int blockHeight)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
## Settings Update
To register new provider please add UseRpcBlockchainProvider=true setting (RPC credentials are configured in RPC section)

## Address Import
To import address in node following curl should be used
```
curl --user myusername:mypassword \
     --data-binary '{"jsonrpc": "1.0", "id":"curl", "method": "importaddress", "params": ["<bitcoin_address>", "<label>", <rescan>, <timestamp> ] }' \
     -H 'content-type: text/plain;' http://localhost:8332/
```
In the command above, you'll need to replace <bitcoin_address> with the actual Bitcoin address you want to import, <label> with a label for the address (optional), <rescan> with a boolean value of true, and <timestamp> with the Unix timestamp corresponding to the date you want to use for the rescan.

### Example
```
curl --user myusername:mypassword \
     --data-binary '{"jsonrpc": "1.0", "id":"curl", "method": "importaddress", "params": ["1ABCDEF123456789", "MyAddress", true, 1641124800 ] }' \
     -H 'content-type: text/plain;' http://localhost:8332/
```